### PR TITLE
fixed README. PyPI package name is disco-dop, Cython needs to be install...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,8 @@ using `pip <http://http://www.pip-installer.org>`_,
 issue the following commands::
 
     sudo apt-get install build-essential python-dev python-numpy python-pip
-    pip install --user discodop
+    pip install --user Cython
+    pip install --user disco-dop
 
 To compile the latest development version on Ubuntu,
 run the following sequence of commands::


### PR DESCRIPTION
...ed beforehand.
