### PR TITLE
add ftbundocompounds

### DIFF
--- a/discodop/ftb_handle_compounds.py
+++ b/discodop/ftb_handle_compounds.py
@@ -1,0 +1,44 @@
+# Please cite the following paper while re-using the code:
+# Candito, M., Crabbé, B., & Denis, P. (2010, May).
+# Statistical French dependency parsing: treebank conversion and first results.
+# In Seventh International Conference on Language Resources and Evaluation-LREC 2010 (pp. 1840-1847).
+# European Language Resources Association (ELRA).
+
+# Copyright: Candito, M., Crabbé, B., & Denis, P.
+
+# regex expressions for repeated compound patterns which will be undone
+RegularCompoundPatterns = {# a N, maybe with Det, Adj, and PPs
+                           # " Organisation_de_coopération_et_de_développement_économique "
+                           # " Institut_de_formation_des_agents_de_voyages"
+                           # " pomme de terre "
+                           # "marché monétaire et obligataire"
+                           # "	Bureau_de_recherches_géologiques_et_minières"
+                           # attention : apres un P, on impose un N qqpart (le code s'appuie là-dessus...)
+                           'N': ['((D )?(A )*N( A( C A)?)*( P(\+D)?( D)?( A)* N( A( C A)?)*(( C)? P(\+D)?( D)?( A)* N)*)?)'],
+                           'V': ['(V )+(P|A|D)*( N)+( P)* | \
+                                 (N|D)( P)*( N)+'], #faire face, faire appel
+                           'P': ['P(\+D)? (D )?(A )*N( P(\+D)?( D)?( A)* N( A( C A)?)*(( C)? P(\+D)?( D)?( A)* N( A)*)*)? P(\+D)?'],
+                           'ADV': ['P(\+D)? (D )?(A )*N( P(\+D)?( D)?( A)* N( A)*)?']}
+
+# The compounds found in the AllowedCompound list should not be undone,
+# those are mostly organization names or fixed expressions like 'aujourd'hui'
+# TODO! extend list of allowed compounds
+
+AllowedCompounds = [
+                    '(MWN (N Fondation) (N France) (A active))',
+                    '(MWN (N Côte) (PONCT -) (P d\') (N Ivoire))',
+                    '(MWP (CL Il) (CL y) (V a))',
+                    '(MWN (N Jean) (PONCT -) (N Louis))',
+                    '(MWADV (ADV tout) (P de) (N suite))',
+                    '(MWP (P jusqu\') (P au))',
+                    '(MWN (A Haute) (PONCT -) (N Corse))',
+                    '(MWP (CL y) (A compris))',
+                    '(MWN (N Chalon) (PONCT -) (P sur) (PONCT -) (N Saône))',
+                    '(MWP (CL il) (CL y) (V a))',
+                    '(MWN (N Royaume) (PONCT -) (A uni))',
+                    '(MWN (N Seine) (PONCT -) (N Saint) (PONCT -) (N Denis))',
+                    '(MWN (N Roche) (PONCT -) (N la) (PONCT -) (N Molière))',
+                    '(MWN (N Air) (N France))',
+                    '(MWN (A Grande) (PONCT -) (N Bretagne))',
+                    '(MWN (N Union) (A soviétique))'
+                    ]

--- a/discodop/treebanktransforms.py
+++ b/discodop/treebanktransforms.py
@@ -11,6 +11,7 @@ from .treebank import EXPORTNONTERMINAL
 from .treetransforms import addfanoutmarkers, removefanoutmarkers
 from .punctuation import punctprune, PUNCTUATION
 from .util import ishead
+from ftb_handle_compounds import RegularCompoundPatterns, AllowedCompounds
 
 FIELDS = tuple(range(6))
 WORD, LEMMA, TAG, MORPH, FUNC, PARENT = FIELDS
@@ -791,6 +792,167 @@ def ftbtransforms(name, tree, sent):
 					sbtree[i:] = []
 					new_tree = ParentedTree('Sint', [ch for ch in children])
 					sbtree.append(new_tree)
+	elif name == 'ftbundocompounds':
+		##########################################################################################################
+		# This function does the "undoing compounds" step as described by Marie Candito et al. in the following paper
+		# Candito, M., Crabbé, B., & Denis, P. (2010, May).
+		# Statistical French dependency parsing: treebank conversion and first results.
+		# In Seventh International Conference on Language Resources and Evaluation-LREC 2010 (pp. 1840-1847).
+		# European Language Resources Association (ELRA).
+
+		# Copyright: Candito, M., Crabbé, B., & Denis, P.
+		###########################################################################################################
+		# In particular, this code does the following:
+		# It systematically undoes compounds that
+		#	(i) have a known regular pattern,
+		#	(ii) and aren't in the allowed compounds list"""
+		###########################################################################################################
+		# return a space-separated string of the children labels
+		def children_labels(subtree):
+			if subtree.children == None or len(subtree.children) < 2: return ""
+			return " ".join([x.label for x in subtree.children])
+
+		# if the sbtree has the label 'P' or 'P+D', it is marked as isP-sbtree
+		def isP(sbtree):
+			return sbtree.label in ['P', 'P+D']
+
+		def set_label(self, label):
+			"""
+                this definition is taken from http://www.nltk.org/_modules/nltk/tree.html
+                Set the sbtree label of the tree.
+            """
+			self.label = label
+
+		# the following functions (make_VP, make_PP, make_NP, make_AP, make_COORD)
+		# create the corresponding trees given the sbtrs
+		def make_VP(sbtrs):
+			vp = ParentedTree('VP', [])
+			vp_subtree = ParentedTree(sbtrs[0].label, sbtrs[0])
+			vp.append(vp_subtree)
+			if isP(sbtrs[1]):
+				pp = make_PP(sbtrs[1:])
+				vp.append(pp)
+				return vp
+			if sbtrs[1].label in ['D', 'N', 'ET']:
+				np = make_NP(sbtrs[1:])
+				vp.append(np)
+				return vp
+			else:
+				vp.children = [sbtrs]
+			return vp
+
+		def make_PP(sbtrs):
+			pp = ParentedTree('PP', [])
+			pp_subtree = ParentedTree(sbtrs[0].label, sbtrs[0])
+			pp.append(pp_subtree)
+			if len(sbtrs) > 1:
+				sbtrs_children = sbtrs[1:]
+				np_subtree = make_NP(sbtrs_children)
+				pp.append(np_subtree)
+			return pp
+
+		def make_NP(sbtrs, beforehead=True):
+			np = ParentedTree("NP", [])
+			while sbtrs != []:
+				if sbtrs[0].label in ['D', 'ET']:
+					np_subtree = ParentedTree(sbtrs[0].label, sbtrs[0])
+					np.append(np_subtree)
+					sbtrs = sbtrs[1:]
+				if sbtrs[0].label == 'N':
+					np_subtree = ParentedTree(sbtrs[0].label, sbtrs[0])
+					np.append(np_subtree)
+					sbtrs = sbtrs[1:]
+				elif sbtrs[0].label == 'A':
+					if len(sbtrs) > 2 and sbtrs[1].label == 'C' and sbtrs[2].label == 'A':
+						ap = make_AP(sbtrs[0:3], 'A C A')
+						np.append(ap)
+						sbtrs = sbtrs[3:]
+					else:
+						ap = ParentedTree("AP", [])
+						ap_subtree = ParentedTree("A", sbtrs[0])
+						ap.append(ap_subtree)
+						np.append(ap)
+						sbtrs = sbtrs[1:]
+				# if a prep is encountered
+				# => treat all remaining sbtrs as a whole PP
+				# (cf. closest attachment preferred)
+				# (unhandled case : N1 (P N2) others : where others attaches to N1)
+				elif sbtrs[0].label in ['P', 'P+D']:
+					pp = make_PP(sbtrs)
+					np.append(pp)
+					sbtrs = []
+				elif sbtrs[0].label == 'C':
+					coord = make_COORD(sbtrs)
+					np.append(coord)
+					sbtrs = []
+			return np
+
+		def make_COORD(sbtrs):
+			coord = ParentedTree('COORD', [])
+			coord_subtree = ParentedTree(sbtrs[0].label, sbtrs[0])
+			coord.append(coord_subtree)
+			# conjunction is supposed to be the first sbtree
+			# if C P ... => coordination of PPs
+			if isP(sbtrs[1]):
+				pp = make_PP(sbtrs[1:])
+				coord.append(pp)
+			# otherwise = coordination of NPs (APs handled differently)
+			else:
+				np = make_NP(sbtrs[1:])
+				coord.append(np)
+			return coord
+
+		def make_AP(sbtrs, cmpd_str):
+			if cmpd_str == 'A':
+				ap = ParentedTree("AP", [])
+				ap_subtree = ParentedTree("A", sbtrs[0])
+				ap.append(ap_subtree)
+			elif cmpd_str == 'A C A':
+				ap = ParentedTree("AP", [])
+				ap_subtree = ParentedTree(sbtrs[0].label, sbtrs[0])
+				ap.append(ap_subtree)
+				coord = ParentedTree('COORD', [])
+				coord_subtree = ParentedTree(sbtrs[1].label, sbtrs[1])
+				coord.append(coord_subtree)
+				ap2 = ParentedTree("AP", [])
+				ap2_subtree = ParentedTree(sbtrs[2].label, sbtrs[2])
+				ap2.append(ap2_subtree)
+				coord.append(ap2)
+				ap.append(coord)
+			return ap
+
+		for sbtree in tree.subtrees():
+			if sbtree.label.startswith("MW"):
+				if str(treebank.writetree(sbtree, item.sent, key, "bracket")).strip() not in AllowedCompounds:
+					base_label = sbtree.label.replace("MW", "")
+					cmpd_str = children_labels(sbtree)
+					if base_label in ['N', 'V', 'P', 'ADV']:
+						for pattern in RegularCompoundPatterns[base_label]:
+							if re.match(pattern + "$", cmpd_str):
+								if base_label == "V" and sbtree.head == True:
+									sbtree_to_append = make_VP(sbtree.children)
+									set_label(sbtree_to_append, "FTBUC-VP")
+									parent = sbtree.parent
+									if sbtree.parent != None:
+										sbtree.parent[:] = []
+										parent.append(sbtree_to_append)
+								elif base_label == 'N':
+									sbtree_to_append = make_NP(sbtree.children, beforehead=True)
+									set_label(sbtree_to_append, "FTBUC-NP")
+									parent = sbtree.parent
+									if sbtree.parent != None:
+										sbtree.parent[:] = []
+										parent.append(sbtree_to_append)
+								elif (isP(sbtree) and sbtree.parent.label != 'VPinf') or base_label == 'ADV':
+									# cases where P is sbtree and P has parent with the label VPinf
+									# are treated in a separate function as PP raising
+									sbtree_to_append = make_PP(sbtree.children)
+									set_label(sbtree_to_append, "FTBUC-PP")
+									parent = sbtree.parent
+									if sbtree.parent != None:
+										sbtree.parent[:] = []
+										parent.append(sbtree_to_append)
+
 	else:
 		return False
 	return True


### PR DESCRIPTION
These two files do the "undoing compounds" step as described by Marie Candito et al. in the following paper:  Candito, M., Crabbé, B., & Denis, P. (2010, May). "Statistical French dependency parsing: treebank conversion and first results." In Seventh International Conference on Language Resources and Evaluation-LREC 2010 (pp. 1840-1847). European Language Resources Association (ELRA).

Copyright: Candito, M., Crabbé, B., & Denis, P.

In particular, the code does the following:  It systematically undoes compounds that (i) have a known regular pattern, (ii) and aren't in the allowed compounds list

TODO @TaniaBladier: extend the AllowedCompounds in ftb_handle_compounds.py