### PR TITLE
Fixed some bugs with FTBXMLReader

### DIFF
--- a/discodop/treebank.py
+++ b/discodop/treebank.py
@@ -587,7 +587,7 @@ def alpinotree(block, functions=None, morphology=None, lemmas=None):
 
 def ftbtree(block, functions=None, morphology=None, lemmas=None):
 	"""Get tree, sent from tree in FTB format given as etree XML object."""
-	def getsubtree(node):
+	def getsubtree(node, parentid):
 		"""Parse a subtree of an FTB tree."""
 		source = [''] * len(FIELDS)
 		nodeid = next(nodeids)
@@ -596,23 +596,64 @@ def ftbtree(block, functions=None, morphology=None, lemmas=None):
 		source[MORPH] = node.get('ee') or ''
 		source[FUNC] = node.get('fct') or ''
 		if node.tag == 'w':
-			if node.get('compound') == 'yes' and len(node):
+			if node.get('compound') == 'yes':
 				source[TAG] = label = 'MW' + node.get('cat')
 				result = ParentedTree(label, [])
-				for child in node:
-					subtree = getsubtree(child)
-					subtree.source[PARENT] = nodeid
-					result.append(subtree)
-			else:  # regular word token
+				"""handle a few cases in FTB where we have a compound consisting
+				 of just one word, e.g. like in sentence number 1497 
+				 in file flmf3_01000_01499ep.aa.xml:
+				 <w cat="CL" compound="yes" ee="CL-suj-3ms" ei="CL3ms"
+				 lemma="il" mph="3ms" subcat="suj">-t-il</w>
+				 otherwise we get an empty node like (MWCL ) instead of (MWCL -t-il)"""
+				if len(node) == 0:
+					result = ParentedTree(source[TAG], [len(sent)])
+					sent.append(node.text)
+					handlemorphology(morphology, lemmas, result, source, sent)
+				else:
+					for child in node:
+						subtree = getsubtree(child, nodeid)
+						subtree.source[PARENT] = nodeid
+						result.append(subtree)
+						sent.append(child.text)
+			else:
 				source[TAG] = node.get('cat') or node.get('catint')
-				result = ParentedTree(source[TAG], [len(sent)])
-				sent.append(re.sub(r'\s+', '', (node.text or '')))
-				handlemorphology(morphology, lemmas, result, source, sent)
+				result = ParentedTree(source[TAG], [])
+				if not node.text:
+					"""handle a few cases in FTB where - because of the differences
+					in annotations - we have a non-compound consisting of several words
+					e.g. like in sentence number 6bis in file flmf7as1ep.cat.xml:
+						 <w cat="ADV" ee="ADV" ei="ADV" lemma="aujourd'hui"> 
+								<w catint="P">Aujourd'</w> 
+								<w catint="N">hui</w>
+						  </w>
+					 otherwise we get an empty node like (ADV ) instead of (ADV (P Aujourd') (N hui))"""
+					if len(node) == 0:
+						result = ParentedTree(source[TAG], [len(sent)])
+						sent.append('')
+						handlemorphology(morphology, lemmas, result, source,
+										 sent)
+					else:
+						for child in node:
+							subtree = getsubtree(child, nodeid)
+							subtree.source[PARENT] = nodeid
+							result.append(subtree)
+							sent.append(child.text)
+				elif (len(node) > 0 and re.match(r"((\s)+\n(\s)+)|((\n)+(\t)*)|((\s)+)", node.text)):
+					for child in node:
+						subtree = getsubtree(child, nodeid)
+						subtree.source[PARENT] = nodeid
+						result.append(subtree)
+						sent.append(child.text)
+				else:
+					result = ParentedTree(source[TAG], [len(sent)])
+					sent.append(node.text.strip())
+					handlemorphology(morphology, lemmas, result, source, sent)
+
 		else:
 			source[TAG] = label = node.tag
 			result = ParentedTree(label, [])
 			for child in node:
-				subtree = getsubtree(child)
+				subtree = getsubtree(child, nodeid)
 				subtree.source[PARENT] = nodeid
 				result.append(subtree)
 			if not result:
@@ -623,11 +664,12 @@ def ftbtree(block, functions=None, morphology=None, lemmas=None):
 
 	sent = []
 	nodeids = count(500)
-	tree = getsubtree(block)
+	tree = getsubtree(block, 0)
 	comment = ' '.join('%s=%r' % (a, block.get(a))
-			for a in ('argument', 'author', 'date', 'textID', 'nb'))
+					   for a in ('argument', 'author', 'date'))
 	handlefunctions(functions, tree, morphology=morphology)
 	return Item(tree, sent, comment, ElementTree.tostring(block))
+
 
 
 def writetree(tree, sent, key, fmt, comment=None, morphology=None,


### PR DESCRIPTION
The changes in code address two issues:

1. handle a few cases in FTB where we have a compound consisting  of just one word, e.g. like in sentence number 1497  in file flmf3_01000_01499ep.aa.xml: <w cat="CL" compound="yes" ee="CL-suj-3ms" ei="CL3ms"  lemma="il" mph="3ms" subcat="suj">-t-il</w> otherwise we get an empty node like (MWCL ) instead of (MWCL -t-il)

2. handle a few cases in FTB where - because of the differences in annotations - we have a non-compound consisting of several words, e.g. like in sentence number 6bis in file flmf7as1ep.cat.xml:  <w cat="ADV" ee="ADV" ei="ADV" lemma="aujourd'hui">  <w catint="P">Aujourd'</w>  <w catint="N">hui</w>  </w>,  otherwise we get an empty node like (ADV ) instead of (ADV (P Aujourd') (N hui))