### PR TITLE
DenseCFGChart: use compactcellidx instead of cellidx for chart

### DIFF
--- a/discodop/containers.pxd
+++ b/discodop/containers.pxd
@@ -735,7 +735,54 @@ cdef inline size_t compactcellidx(short start, short end, short lensent,
 	"""Return an index to a triangular array, given start < end.
 	The result of this function is the index to chart[start][end][0]."""
 	return nonterminals * (lensent * start
-			- ((start - 1) * start / 2) + end - start - 1)
+			- ((start - 1) * start // 2) + end - start - 1)
+
+
+cdef inline short compactcell_to_start(size_t cell, short lensent,
+		Label nonterminals):
+	"""Retrieve start position for a given compact chart cell."""
+	cell = cell // nonterminals
+	cdef short start = 0, idx = 0
+	while idx + lensent <= cell:
+		idx += lensent
+		lensent -= 1
+		start += 1
+	return start
+
+
+# alternative implementation in closed form (slower)
+# requires: from libc.math cimport sqrt
+#
+# cdef inline short compactcell_to_start(size_t cell, short lensent,
+# 		Label nonterminals):
+# 	"""Retrieve start position for a given compact chart cell."""
+# 	return int(lensent + 0.5 \
+# 		   - sqrt(0.25 + lensent * (lensent + 1) - 2 * (cell // nonterminals)))
+
+
+cdef inline short compactcell_to_end(size_t cell, short lensent,
+		Label nonterminals):
+	"""Retrieve end position for a given compact chart cell."""
+	cell = cell // nonterminals
+	cdef short start = 0, idx = 0
+	while idx + lensent <= cell:
+		idx += lensent
+		lensent -= 1
+		start += 1
+	return start + (cell - idx) + 1
+
+
+# alternative implementation in closed form (slower)
+# requires: from libc.math cimport sqrt, modf
+#
+# cdef inline short compactcell_to_end(size_t cell, short lensent,
+# 		Label nonterminals):
+# 	"""Retrieve end position for a given compact chart cell."""
+# 	cdef double fractional, start
+# 	fractional = modf(lensent + 0.5 - sqrt(
+# 				0.25 + lensent * (lensent + 1) - 2 * (cell // nonterminals)),
+# 			&start)
+# 	return start + round((lensent - start) * fractional) + 1
 
 
 cdef object log1e200 = log(1e200)

--- a/discodop/pcfg.pxd
+++ b/discodop/pcfg.pxd
@@ -6,6 +6,7 @@ from cpython.dict cimport PyDict_Contains, PyDict_GetItem
 from cpython.float cimport PyFloat_AS_DOUBLE
 from .containers cimport (Chart, Grammar, ProbRule, LexicalRule,
 		Edge, RankedEdge, Idx, Prob, Label, ItemNo, cellidx, compactcellidx,
+		compactcell_to_start, compactcell_to_end,
 		sparse_hash_map, sparse_hash_set, Agenda, Whitelist,
 		SmallChartItem, FatChartItem, CFGtoSmallChartItem, CFGtoFatChartItem)
 


### PR DESCRIPTION
Changed `DenseCFGChart` to use the compact cell indexing function for addressing chart items. This should asymptotically halve the memory footprint (of the PCFG stage). 
Based on a 100-sentence test corpus the number of items and the Viterbi parse trees are identical to the 
upstream version. The tighter memory layout also seems to cause a speedup of about 10% (for the PCFG stage).