### PR TITLE
Fix collapseunary

### DIFF
--- a/discodop/treetransforms.py
+++ b/discodop/treetransforms.py
@@ -329,6 +329,9 @@ def collapseunary(tree, collapsepos=False, collapseroot=False, joinchar='+'):
 					and (collapsepos or isinstance(node[0, 0], Tree))):
 				node.label += joinchar + node[0].label
 				node[0:] = [child for child in node[0]]
+                # remove previous parents from the children
+                for i, child in enumerate(node[0]):
+                    node[0]._delparent(child, i)
 				# since we assigned the child's children to the current node,
 				# evaluate the current node again
 				agenda.append(node)


### PR DESCRIPTION
I got a ValueError from applying `treetransforms.collapseunary` on 
`(B (E (C (a 0) (b 1)) (c 2)))`, ecpecting `(B+E (C (a 0) (b 1)) (c 2))`:

```ValueError: Cannot insert a subtree that already has a parent.```

I found, that this occurs, because the parent reference `E` is not deleted in `E`s children before they are assigned to the new parent `B+E`.

